### PR TITLE
update IBM CloudPak for Data - core images

### DIFF
--- a/reference/image-manifests/ibm-cp-datacore.yaml
+++ b/reference/image-manifests/ibm-cp-datacore.yaml
@@ -113,10 +113,12 @@ images:
   - image: cp/cpd/knol
   - image: cp/cpd/kubectlclient-ubi
   - image: cp/cpd/metadata-api-server-x86_64
+  - image: cp/cpd/metadata-discovery
   - image: cp/cpd/metadata-engine-x86_64
   - image: cp/cpd/mlrepositoryservicehydra
   - image: cp/cpd/model-operation-service-scheduling
   - image: cp/cpd/model-risk-management
+  - image: cp/cpd/model_viewer 
   - image: cp/cpd/ngp-projects-api
   - image: cp/cpd/nlq-search
   - image: cp/cpd/nlq-search-extractor


### PR DESCRIPTION
Manual update of two images that are no in the super manifest