### PR TITLE
Update ibm-storage-ceph.yaml

### DIFF
--- a/reference/image-manifests/ibm-storage-ceph.yaml
+++ b/reference/image-manifests/ibm-storage-ceph.yaml
@@ -6,17 +6,24 @@ images:
   - image: cp/ibm-ceph/ceph-6-dashboard-rhel9
   - image: cp/ibm-ceph/ceph-6-rhel9
   - image: cp/ibm-ceph/ceph-7-rhel9
+  - image: cp/ibm-ceph/ceph-8-crimson-rhel9
+  - image: cp/ibm-ceph/ceph-8-rhel9
+  - image: cp/ibm-ceph/cephcsi
   - image: cp/ibm-ceph/grafana-rhel9
   - image: cp/ibm-ceph/haproxy-rhel8
   - image: cp/ibm-ceph/haproxy-rhel9
   - image: cp/ibm-ceph/keepalived-rhel8
   - image: cp/ibm-ceph/keepalived-rhel9
   - image: cp/ibm-ceph/logging-loki-rhel8
+  - image: cp/ibm-ceph/nginx-124-rhel9
   - image: cp/ibm-ceph/nvmeof-cli-rhel9
   - image: cp/ibm-ceph/nvmeof-rhel9
+  - image: cp/ibm-ceph/oauth2-proxy-rhel9
   - image: cp/ibm-ceph/prometheus
   - image: cp/ibm-ceph/prometheus-alertmanager
   - image: cp/ibm-ceph/prometheus-node-exporter
   - image: cp/ibm-ceph/promtail-rhel9
+  - image: cp/ibm-ceph/samba-metrics-rhel9
+  - image: cp/ibm-ceph/samba-server-rhel9
   - image: cp/ibm-ceph/snmp-notifier-rhel8
   - image: cp/ibm-ceph/snmp-notifier-rhel9


### PR DESCRIPTION
Manually update the super manifest for ibm-ceph.

`ibm-ceph` had `publish:exclude `for CASE, but due to gap in CSDP, even `supermanifest` was **not** published. 

A couple of months back, we had done similar exercise for `webmethods` CASE entries. 

