### PR TITLE
Update ibm-connect-direct.yaml

### DIFF
--- a/reference/image-manifests/ibm-connect-direct.yaml
+++ b/reference/image-manifests/ibm-connect-direct.yaml
@@ -14,6 +14,7 @@ images:
   - image: cp/ibm-connectdirect/cdu6.3_certified_container_6.3.0.1
   - image: cp/ibm-connectdirect/cdu6.3_certified_container_6.3.0.2
   - image: cp/ibm-connectdirect/cdu6.3_certified_container_6.3.0.3
+  - image: cp/ibm-connectdirect/cdu6.3_certified_container_6.3.0.4
   - image: cp/ibm-connectdirect/cdu6.4_certified_container_6.4.0.0
   - image: cp/ibm-connectdirect/cdu6.4_certified_container_6.4.0.1
   - image: hyc-icpcontent-docker-local.artifactory.swg-devops.com/ibm-connectdirect


### PR DESCRIPTION
This entry was not present in super manifest. 

Hence, entitled customers were not able to pull it. 

```
podman pull cp.icr.io/cp/ibm-connectdirect/cdu6.3_certified_container_6.3.0.4:6.3.0.4_iFix015
Trying to pull cp.icr.io/cp/ibm-connectdirect/cdu6.3_certified_container_6.3.0.4:6.3.0.4_iFix015...
Error: initializing source docker://cp.icr.io/cp/ibm-connectdirect/cdu6.3_certified_container_6.3.0.4:6.3.0.4_iFix015: reading manifest 6.3.0.4_iFix015 in cp.icr.io/cp/ibm-connectdirect/cdu6.3_certified_container_6.3.0.4: denied:

```