### PR TITLE
Delete reference/image-manifests/ibm-dpod-cloud-agent.yaml

### DIFF
--- a/reference/image-manifests/ibm-dpod-cloud-agent.yaml
+++ b/reference/image-manifests/ibm-dpod-cloud-agent.yaml
@@ -1,8 +1,0 @@
-source: ibm-dpod-cloud-agent
-description: "The CASE for the DataPower Operations Dashboard Cloud Agent"
-images:
-  - image: cp/dpod/dpod-cloud-agent-api-proxy
-  - image: cp/dpod/dpod-cloud-agent-http-ingester
-  - image: cp/dpod/dpod-cloud-agent-manager
-  - image: cp/dpod/dpod-cloud-agent-messaging-broker
-  - image: cp/dpod/dpod-cloud-agent-syslog-ingester


### PR DESCRIPTION
It is our old known issue.

https://github.com/IBM/cloud-pak/pull/809

`delete the existing supermanifest for an excluded CASE so that its manifest is processed again when a new version of SAME CASE is processed by CSDP `

This release ( current one ) has only one CASE.

 `CI_CHANGED_CASES=repo/case/ibm-dpod-cloud-agent/1.3.3/ibm-dpod-cloud-agent-1.3.3.tgz`